### PR TITLE
Load actual STL segments instead of placeholders

### DIFF
--- a/src/utils/GeometryUtils.ts
+++ b/src/utils/GeometryUtils.ts
@@ -39,10 +39,9 @@ export class GeometryUtils {
   static calculateGaussianCurvature(
     vertexIndex: number,
     position: BufferAttribute,
-    normal: BufferAttribute
+    _normal: BufferAttribute
   ): number {
     const vertex = new Vector3().fromBufferAttribute(position, vertexIndex)
-    const vertexNormal = new Vector3().fromBufferAttribute(normal, vertexIndex)
     
     const neighbors = this.getVertexNeighbors(vertexIndex, position, 3.0)
     if (neighbors.length < 3) return 0
@@ -234,8 +233,7 @@ export class GeometryUtils {
     vertices.forEach(v => center.add(v))
     center.divideScalar(vertices.length)
     
-    // Calculate covariance matrix for PCA
-    const covariance = new Matrix3()
+    // Prepare centered vertices for approximate PCA
     const centered = vertices.map(v => v.clone().sub(center))
     
     // This is a simplified implementation


### PR DESCRIPTION
## Summary
- Replace placeholder sphere generation with real segment mesh loading in the viewer
- Implement STL segment download and parsing via `STLLoader`
- Remove unused variables in geometry utilities to allow TypeScript build

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688e75a425cc83228dafec256aa430a8