### PR TITLE
Fix sidebar update on segmentation and remove unused tools

### DIFF
--- a/src/components/DentalViewer.vue
+++ b/src/components/DentalViewer.vue
@@ -126,11 +126,8 @@ const backgroundSegmentationStatus = ref<{
 const interactionModes: InteractionMode["mode"][] = [
   "select",
   "lasso",
-  "brush",
   "move",
   "rotate",
-  "merge",
-  "split",
 ];
 
 // Three.js objects
@@ -362,9 +359,6 @@ function onMouseMove(event: MouseEvent) {
         select: "pointer",
         rotate: "grab",
         move: "move",
-        brush: "crosshair",
-        merge: "pointer",
-        split: "pointer",
       };
       renderer.domElement.style.cursor =
         cursorMap[currentMode.value] || "default";
@@ -478,9 +472,6 @@ function onKeyUp(event: KeyboardEvent) {
       select: "pointer",
       rotate: "grab",
       move: "move",
-      brush: "crosshair",
-      merge: "pointer",
-      split: "pointer",
     };
     renderer.domElement.style.cursor =
       cursorMap[currentMode.value] || "default";
@@ -1080,6 +1071,9 @@ async function performManualSegmentation() {
       dentalModel.value.segments.push(newSegment);
       scene.add(newSegment.mesh);
 
+      // Ensure reactivity for newly added segment
+      dentalModel.value = { ...dentalModel.value };
+
       // IMPORTANT: Keep the original mesh visible for subsequent lasso operations
       dentalModel.value.originalMesh.visible = true;
 
@@ -1528,9 +1522,6 @@ function setInteractionMode(mode: InteractionMode["mode"]) {
       select: "pointer",
       rotate: "grab",
       move: "move",
-      brush: "crosshair",
-      merge: "pointer",
-      split: "pointer",
     };
     renderer.domElement.style.cursor = cursorMap[mode] || "default";
     console.log(
@@ -1708,6 +1699,7 @@ function clearExistingSegments() {
   
   // Clear segments array
   dentalModel.value.segments = [];
+  dentalModel.value = { ...dentalModel.value };
   selectedSegments.value = [];
   
   console.log("Cleared existing manual segments for AI segmentation");
@@ -1729,6 +1721,9 @@ async function createAISegments(result: SegmentationResult): Promise<void> {
         scene.add(segment.mesh);
       }
     }
+
+    // Force reactivity update so sidebar reflects new segments
+    dentalModel.value = { ...dentalModel.value };
 
     console.log(`Created ${result.segments.length} AI-segmented tooth segments`);
     console.log(`Session ID: ${result.sessionId} - Use this to download individual STL files`);

--- a/src/components/MovementControls.vue
+++ b/src/components/MovementControls.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="movement-controls" v-if="selectedSegments.length > 0">
     <div class="movement-header">
-      <span class="movement-icon">◈</span>
+      <span class="movement-icon">🛠️</span>
       <span class="movement-title">Movement</span>
     </div>
     
@@ -12,7 +12,7 @@
         :disabled="totalMovementDistance === 0"
         class="btn btn-secondary movement-btn"
       >
-        <span>⟲</span> Reset
+        <span>🔄</span> Reset
       </button>
     </div>
     
@@ -134,7 +134,7 @@ function stopDirectionalMove() {
 }
 
 .movement-icon {
-  font-size: 16px;
+  font-size: 18px;
   color: #06b6d4;
 }
 

--- a/src/components/TopToolbar.vue
+++ b/src/components/TopToolbar.vue
@@ -121,10 +121,10 @@ function getUploadButtonText(): string {
 
 function getModeIcon(mode: InteractionMode['mode']): string {
   const icons = {
-    select: '◉',
-    lasso: '○',
-    move: '⧨',
-    rotate: '⟲'
+    select: '🖱️',
+    lasso: '✏️',
+    move: '✋',
+    rotate: '🔄'
   }
   return icons[mode] || '◈'
 }
@@ -295,7 +295,7 @@ function getInteractionModeTitle(mode: InteractionMode['mode']): string {
 }
 
 .btn-icon {
-  font-size: 16px;
+  font-size: 18px;
 }
 
 .btn-icon.rotating {

--- a/src/components/TopToolbar.vue
+++ b/src/components/TopToolbar.vue
@@ -123,38 +123,24 @@ function getModeIcon(mode: InteractionMode['mode']): string {
   const icons = {
     select: '◉',
     lasso: '○',
-    brush: '◎',
     move: '⧨',
-    rotate: '⟲',
-    merge: '⧻',
-    split: '⧰'
+    rotate: '⟲'
   }
   return icons[mode] || '◈'
 }
 
-function isInteractionModeDisabled(mode: InteractionMode['mode']): boolean {
-  if (!props.dentalModel) return true
-  
-  const existingSegmentModes: InteractionMode['mode'][] = ['merge', 'split']
-  
-  if (existingSegmentModes.includes(mode)) {
-    return props.dentalModel.segments.length === 0
-  }
-  
-  return false
+function isInteractionModeDisabled(_mode: InteractionMode['mode']): boolean {
+  return !props.dentalModel
 }
 
 function getInteractionModeTitle(mode: InteractionMode['mode']): string {
   const titles = {
     select: 'Click to select individual segments',
-    lasso: props.dentalModel?.segments.length === 0 
-      ? 'Draw lasso to create new segments manually' 
+    lasso: props.dentalModel?.segments.length === 0
+      ? 'Draw lasso to create new segments manually'
       : 'Draw lasso to select multiple segments',
-    brush: 'Brush to paint selection',
     move: 'Move selected segments',
-    rotate: 'Rotate view (drag to orbit camera)',
-    merge: 'Merge selected segments',
-    split: 'Split selected segment'
+    rotate: 'Rotate view (drag to orbit camera)'
   }
   return titles[mode] || mode.charAt(0).toUpperCase() + mode.slice(1)
 }

--- a/src/components/ViewportArea.vue
+++ b/src/components/ViewportArea.vue
@@ -9,9 +9,6 @@
           <span v-if="currentMode !== 'select'" class="current-mode">
             {{ getModeIcon(currentMode) }} {{ currentMode.toUpperCase() }}
           </span>
-          <span v-if="dentalModel && dentalModel.segments.length === 0 && (currentMode === 'merge' || currentMode === 'split')" class="mode-hint">
-            Create segments first
-          </span>
         </div>
       </div>
       
@@ -47,11 +44,8 @@ function getModeIcon(mode: InteractionMode['mode']): string {
   const icons = {
     select: '◉',
     lasso: '○',
-    brush: '◎',
     move: '⧨',
-    rotate: '⟲',
-    merge: '⧻',
-    split: '⧰'
+    rotate: '⟲'
   }
   return icons[mode] || '◈'
 }

--- a/src/components/ViewportArea.vue
+++ b/src/components/ViewportArea.vue
@@ -42,10 +42,10 @@ const canvasContainer = ref<HTMLDivElement>()
 // Functions
 function getModeIcon(mode: InteractionMode['mode']): string {
   const icons = {
-    select: '◉',
-    lasso: '○',
-    move: '⧨',
-    rotate: '⟲'
+    select: '🖱️',
+    lasso: '✏️',
+    move: '✋',
+    rotate: '🔄'
   }
   return icons[mode] || '◈'
 }

--- a/src/types/dental.ts
+++ b/src/types/dental.ts
@@ -35,7 +35,7 @@ export interface DentalModel {
 }
 
 export interface InteractionMode {
-  mode: 'select' | 'lasso' | 'brush' | 'move' | 'rotate' | 'merge' | 'split'
+  mode: 'select' | 'lasso' | 'move' | 'rotate'
 }
 
 export interface MovementAxis {


### PR DESCRIPTION
## Summary
- force reactivity on segmentation results so sidebar updates immediately
- simplify toolbar to only include active tools

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e7df2f00c832293dc6bf20dbfe1b4