### PR TITLE
Add voxel-based segmentation fallback

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,11 +1,11 @@
 # 3D Dental Segmentation API Backend
 
-A FastAPI-based backend service for segmenting STL dental models into individual teeth using Open3D and DBSCAN clustering.
+A FastAPI-based backend service for segmenting STL dental models into individual teeth using Open3D and advanced clustering strategies.
 
 ## Features
 
 - **STL File Processing**: Upload and process STL dental models
-- **Automatic Teeth Segmentation**: Uses DBSCAN clustering to identify individual teeth
+- **Automatic Teeth Segmentation**: Combines connected-components, DBSCAN and voxel-based morphology to identify individual teeth
 - **Point Cloud Analysis**: Converts mesh to point cloud for clustering analysis
 - **RESTful API**: Clean REST endpoints for frontend integration
 - **Session Management**: Track segmentation sessions and results

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ python-multipart>=0.0.6
 numpy>=1.21.0
 open3d>=0.15.0
 scikit-learn>=1.0.0
+scipy>=1.7.0

--- a/backend/segmentation_service.py
+++ b/backend/segmentation_service.py
@@ -249,12 +249,17 @@ class DentalSegmentationService:
             except Exception as e:
                 print(f"Clustering failed with {params}: {e}")
                 continue
-        
+
+        if len(best_segments) == 0:
+            # Try voxel-based morphological segmentation before slicing
+            print("Clustering failed, attempting voxel-based segmentation...")
+            best_segments = self._segment_by_voxelization(mesh, config)
+
         if len(best_segments) == 0:
             # Final fallback: slice the mesh into regions
-            print("All clustering failed, slicing mesh into regions...")
+            print("Voxel segmentation failed, slicing mesh into regions...")
             best_segments = self._slice_mesh_into_regions(mesh, config)
-        
+
         return best_segments
     
     def _score_segmentation_result(self, segments: List[Dict], expected_count: int) -> float:
@@ -334,7 +339,66 @@ class DentalSegmentationService:
                     "mesh": segment_mesh,
                     "method": "mesh_mapped_clustering"
                 })
-        
+
+        return segments
+
+    def _segment_by_voxelization(self, mesh: o3d.geometry.TriangleMesh, config: Dict) -> List[Dict]:
+        """Segment the mesh by converting to a voxel grid and labeling components"""
+        print("Attempting voxel-based segmentation...")
+
+        voxel_size = config.get('voxel_size', 0.4)
+        min_voxels = config.get('min_voxel_size', 30)
+        min_triangles = config.get('min_tooth_size', 50)
+
+        try:
+            voxel_grid = o3d.geometry.VoxelGrid.create_from_triangle_mesh(mesh, voxel_size)
+        except Exception as e:
+            print(f"Voxelization failed: {e}")
+            return []
+
+        voxels = voxel_grid.get_voxels()
+        if len(voxels) == 0:
+            return []
+
+        indices = np.array([v.grid_index for v in voxels])
+        min_idx = indices.min(axis=0)
+        max_idx = indices.max(axis=0) + 1
+        grid_shape = max_idx - min_idx
+        volume = np.zeros(grid_shape, dtype=bool)
+        for v in voxels:
+            volume[tuple(v.grid_index - min_idx)] = True
+
+        from scipy.ndimage import binary_opening, label, generate_binary_structure
+        structure = generate_binary_structure(3, 1)
+        opened = binary_opening(volume, structure)
+        labeled, num_features = label(opened, structure)
+
+        bbox_min = mesh.get_axis_aligned_bounding_box().min_bound
+        segments = []
+
+        for i in range(1, num_features + 1):
+            mask = labeled == i
+            if np.sum(mask) < min_voxels:
+                continue
+
+            coords = np.argwhere(mask) + min_idx
+            min_bound = bbox_min + coords.min(axis=0) * voxel_size
+            max_bound = bbox_min + (coords.max(axis=0) + 1) * voxel_size
+            aabb = o3d.geometry.AxisAlignedBoundingBox(min_bound, max_bound)
+            segment_mesh = mesh.crop(aabb)
+
+            segment_mesh.remove_duplicated_vertices()
+            segment_mesh.remove_duplicated_triangles()
+            segment_mesh.remove_degenerate_triangles()
+
+            if len(segment_mesh.triangles) >= min_triangles:
+                segment_mesh.compute_vertex_normals()
+                segments.append({
+                    "mesh": segment_mesh,
+                    "method": "voxel_cc"
+                })
+
+        print(f"Voxel segmentation created {len(segments)} segments")
         return segments
     
     def _slice_mesh_into_regions(self, mesh: o3d.geometry.TriangleMesh, config: Dict) -> List[Dict]:


### PR DESCRIPTION
## Summary
- add voxel-based morphological segmentation for STL teeth meshes
- use the new method when DBSCAN clustering fails before falling back to spatial slicing
- document the improved pipeline and add SciPy dependency

## Testing
- `python -m py_compile backend/segmentation_service.py`


------
https://chatgpt.com/codex/tasks/task_e_688e82b1b21c8322863c1df5c2aab2bd