### PR TITLE
Add watershed-based STL tooth segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ npm run dev
 ### 🤖 AI-Powered Segmentation
 - **Automatic Teeth Segmentation**: Upload STL files to backend for automatic segmentation
 - **DBSCAN Clustering**: Uses point cloud clustering to identify individual teeth
+- **Watershed Refinement**: Applies distance-transform watershed on voxel grids to split touching teeth
 - **Session Management**: Track segmentation sessions and results
 - **Segment Download**: Download individual teeth as PLY files
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -5,7 +5,7 @@ A FastAPI-based backend service for segmenting STL dental models into individual
 ## Features
 
 - **STL File Processing**: Upload and process STL dental models
-- **Automatic Teeth Segmentation**: Combines connected-components, DBSCAN and voxel-based morphology to identify individual teeth
+- **Automatic Teeth Segmentation**: Combines connected-components, DBSCAN, voxel-based morphology and watershed refinement to identify individual teeth
 - **Point Cloud Analysis**: Converts mesh to point cloud for clustering analysis
 - **RESTful API**: Clean REST endpoints for frontend integration
 - **Session Management**: Track segmentation sessions and results


### PR DESCRIPTION
## Summary
- add watershed-based voxel segmentation to better separate touching teeth
- document watershed refinement in project READMEs

## Testing
- `npm test` *(fails: Missing script "test")*
- `pytest` *(no tests found)*
- `python -m py_compile backend/segmentation_service.py`
- `pip install scipy scikit-image scikit-learn open3d` *(fails: Could not find a version that satisfies the requirement scipy)*

------
https://chatgpt.com/codex/tasks/task_e_688e8c0e8be48322b0357b2cd9c67f52