### PR TITLE
Add gum isolation before tooth segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ npm run dev
 
 ### 🤖 AI-Powered Segmentation
 - **Automatic Teeth Segmentation**: Upload STL files to backend for automatic segmentation
+- **Gum Isolation**: Separates gum tissue before segmenting individual teeth
 - **DBSCAN Clustering**: Uses point cloud clustering to identify individual teeth
 - **Watershed Refinement**: Applies distance-transform watershed on voxel grids to split touching teeth
 - **Session Management**: Track segmentation sessions and results

--- a/backend/services/algorithms/__init__.py
+++ b/backend/services/algorithms/__init__.py
@@ -7,21 +7,34 @@ from .curvature_sampling import segment_by_curvature_and_sampling
 from .voxelization import segment_by_voxelization
 from .watershed import segment_by_watershed
 from .spatial_slice import slice_mesh_into_regions
+from .gum_segmentation import split_gum_and_teeth
 
 
 def segment_mesh(mesh: o3d.geometry.TriangleMesh, config: Dict) -> List[Dict]:
-    """Segment mesh using multiple approaches for dental separation."""
+    """Segment mesh into gums and individual teeth."""
     print("Attempting mesh segmentation...")
-    triangle_clusters, cluster_n_triangles, _ = mesh.cluster_connected_triangles()
+
+    segments: List[Dict] = []
+
+    # First separate gums from teeth
+    gum_mesh, teeth_mesh = split_gum_and_teeth(mesh, config)
+    if len(gum_mesh.triangles) > 0:
+        segments.append({"mesh": gum_mesh, "method": "gum"})
+
+    # Perform tooth segmentation on the remaining mesh
+    triangle_clusters, cluster_n_triangles, _ = teeth_mesh.cluster_connected_triangles()
     triangle_clusters = np.asarray(triangle_clusters)
     cluster_n_triangles = np.asarray(cluster_n_triangles)
-    print(f"Found {len(cluster_n_triangles)} connected components")
+    print(f"Found {len(cluster_n_triangles)} connected components in teeth mesh")
     if len(cluster_n_triangles) > 1:
-        segments = extract_connected_components(mesh, triangle_clusters, cluster_n_triangles, config)
-        if len(segments) > 0:
+        tooth_segments = extract_connected_components(teeth_mesh, triangle_clusters, cluster_n_triangles, config)
+        if len(tooth_segments) > 0:
+            segments.extend(tooth_segments)
             return segments
     print("Connected components failed, trying curvature-based segmentation...")
-    return segment_by_curvature_and_sampling(mesh, config)
+    tooth_segments = segment_by_curvature_and_sampling(teeth_mesh, config)
+    segments.extend(tooth_segments)
+    return segments
 
 
 __all__ = [
@@ -31,4 +44,5 @@ __all__ = [
     "segment_by_voxelization",
     "segment_by_watershed",
     "slice_mesh_into_regions",
+    "split_gum_and_teeth",
 ]

--- a/backend/services/algorithms/gum_segmentation.py
+++ b/backend/services/algorithms/gum_segmentation.py
@@ -1,0 +1,43 @@
+import numpy as np
+import open3d as o3d
+from typing import Dict, Tuple
+
+
+def split_gum_and_teeth(mesh: o3d.geometry.TriangleMesh, config: Dict) -> Tuple[o3d.geometry.TriangleMesh, o3d.geometry.TriangleMesh]:
+    """Separate gums from teeth using a simple height threshold.
+
+    The function estimates the vertical axis using PCA, then classifies
+    triangles below a certain height percentile as gums and the rest as teeth.
+    """
+    print("Separating gums from teeth...")
+    vertices = np.asarray(mesh.vertices)
+    triangles = np.asarray(mesh.triangles)
+    if len(vertices) == 0 or len(triangles) == 0:
+        return mesh, o3d.geometry.TriangleMesh()
+
+    # Estimate vertical axis using PCA
+    centered = vertices - vertices.mean(axis=0)
+    _, _, vh = np.linalg.svd(centered, full_matrices=False)
+    vertical_axis = vh[2]
+
+    # Project vertices onto vertical axis to get relative heights
+    heights = centered @ vertical_axis
+    percentile = config.get("gum_height_percentile", 25)
+    threshold = np.percentile(heights, percentile)
+
+    # Triangles with all vertices below threshold are considered gum
+    mask = np.all(heights[triangles] < threshold, axis=1)
+    gum_triangles = np.where(mask)[0]
+    teeth_triangles = np.where(~mask)[0]
+
+    gum_mesh = mesh.select_by_index(gum_triangles)
+    teeth_mesh = mesh.select_by_index(teeth_triangles)
+
+    for m in [gum_mesh, teeth_mesh]:
+        m.remove_duplicated_vertices()
+        m.remove_duplicated_triangles()
+        m.remove_degenerate_triangles()
+        if len(m.triangles) > 0:
+            m.compute_vertex_normals()
+
+    return gum_mesh, teeth_mesh

--- a/src/components/DentalViewer.vue
+++ b/src/components/DentalViewer.vue
@@ -63,6 +63,7 @@ import type {
   InteractionMode,
   SegmentationResult,
   SegmentData,
+  ToothType,
 } from "../types/dental";
 import TopToolbar from "./TopToolbar.vue";
 import LeftSidebar from "./LeftSidebar.vue";
@@ -1799,13 +1800,13 @@ async function createSegmentFromData(sessionId: string, segmentData: SegmentData
     );
 
     const segment: ToothSegment = {
-      id: `ai_tooth_${segmentData.id}`,
-      name: segmentData.name || `AI Tooth ${segmentData.id + 1}`,
+      id: `ai_segment_${segmentData.id}`,
+      name: segmentData.name || (segmentData.toothType === 'gum' ? 'Gum' : `AI Tooth ${segmentData.id + 1}`),
       mesh: mesh,
       originalVertices: [],
       centroid: centroid,
       color: color,
-      toothType: 'molar',
+      toothType: (segmentData.toothType as ToothType) || 'molar',
       isSelected: false,
       movementDistance: 0,
       originalPosition: mesh.position.clone(),

--- a/src/services/SegmentationService.ts
+++ b/src/services/SegmentationService.ts
@@ -58,7 +58,7 @@ export class SegmentationService {
         originalFile: file.name,
         segments: result.segments.map((segment: any) => ({
           id: segment.id,
-          name: `Tooth ${segment.id + 1}`,
+          name: segment.tooth_type === 'gum' ? 'Gum' : `Tooth ${segment.tooth_number}`,
           filename: segment.filename,
           pointCount: segment.point_count || segment.vertex_count,
           center: segment.center,
@@ -67,7 +67,8 @@ export class SegmentationService {
           downloadUrl: segment.download_url,
           visible: true,
           selected: false,
-          color: this.generateSegmentColor(segment.id)
+          color: segment.tooth_type === 'gum' ? '#FFC0CB' : this.generateSegmentColor(segment.id),
+          toothType: segment.tooth_type
         })),
         timestamp: new Date(),
         status: 'completed'

--- a/src/types/dental.ts
+++ b/src/types/dental.ts
@@ -1,6 +1,6 @@
 import { Vector3, Mesh, Color } from 'three'
 
-export type ToothType = 'incisor' | 'canine' | 'premolar' | 'molar' | 'wisdom'
+export type ToothType = 'incisor' | 'canine' | 'premolar' | 'molar' | 'wisdom' | 'gum'
 
 export interface ToothSegment {
   id: string
@@ -86,4 +86,5 @@ export interface SegmentData {
   visible: boolean
   selected: boolean
   color: string
+  toothType?: string
 }


### PR DESCRIPTION
## Summary
- segment gums from teeth via height-based PCA analysis
- handle gum segment in backend export and frontend models
- document gum isolation step for AI segmentation

## Testing
- `python -m py_compile backend/services/algorithms/gum_segmentation.py backend/services/algorithms/__init__.py backend/services/segmentation_service.py`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68906c7cbec88322a49ba0cf68dc3281