### PR TITLE
Add orthodontic treatment plan scaffolding

### DIFF
--- a/src/components/LeftSidebar.vue
+++ b/src/components/LeftSidebar.vue
@@ -47,11 +47,17 @@
         </div>
       </div>
     </div>
+
+    <TreatmentPlanPanel
+      v-if="dentalModel && dentalModel.segments.length > 0"
+      :segments="dentalModel.segments"
+    />
   </div>
 </template>
 
 <script setup lang="ts">
 import SegmentItem from './SegmentItem.vue'
+import TreatmentPlanPanel from './TreatmentPlanPanel.vue'
 import type { DentalModel, ToothSegment } from '../types/dental'
 
 // Props

--- a/src/components/TreatmentPlanPanel.vue
+++ b/src/components/TreatmentPlanPanel.vue
@@ -1,0 +1,96 @@
+<template>
+  <div class="panel treatment-plan" v-if="plan.teeth.length">
+    <div class="panel-header">
+      <span class="panel-icon">🗓️</span>
+      <span class="panel-title">Treatment Plan</span>
+    </div>
+    <div class="panel-content">
+      <table class="plan-table">
+        <thead>
+          <tr>
+            <th>Tooth</th>
+            <th v-for="dir in directions" :key="dir">{{ dirLabels[dir] }} Start</th>
+            <th v-for="dir in directions" :key="dir + '-steps'">{{ dirLabels[dir] }} Steps</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="tooth in plan.teeth" :key="tooth.toothId">
+            <td>{{ tooth.toothName }}</td>
+            <td v-for="dir in directions" :key="tooth.toothId + dir + 'start'">
+              <input type="number" min="0" v-model.number="getSchedule(tooth, dir).startStep" />
+            </td>
+            <td v-for="dir in directions" :key="tooth.toothId + dir + 'steps'">
+              <input type="number" min="1" v-model.number="getSchedule(tooth, dir).steps" />
+              <span class="warning" v-if="getSchedule(tooth, dir).steps < standardSteps[dir]">⚠️</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div class="panel-footer">
+      <button class="btn btn-secondary btn-compact" @click="exportPlan">Export Step STLs</button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { reactive, watch } from 'vue'
+import type { ToothSegment, TreatmentPlan, MovementDirection, ToothMovementPlan } from '../types/dental'
+import TreatmentPlanService, { STANDARD_MOVEMENT_STEPS } from '../services/TreatmentPlanService'
+
+interface Props {
+  segments: ToothSegment[]
+}
+
+const props = defineProps<Props>()
+
+const directions: MovementDirection[] = ['anteroposterior', 'vertical', 'transverse']
+const dirLabels: Record<MovementDirection, string> = {
+  anteroposterior: 'AP',
+  vertical: 'Vertical',
+  transverse: 'Transverse',
+}
+
+const standardSteps = STANDARD_MOVEMENT_STEPS
+
+const plan = reactive<TreatmentPlan>(TreatmentPlanService.createPlan(props.segments))
+
+watch(
+  () => props.segments,
+  (newSegs) => {
+    const newPlan = TreatmentPlanService.createPlan(newSegs)
+    plan.teeth.splice(0, plan.teeth.length, ...newPlan.teeth)
+  }
+)
+
+function getSchedule(tooth: ToothMovementPlan, dir: MovementDirection) {
+  return tooth.schedules.find(s => s.direction === dir) as any
+}
+
+function exportPlan() {
+  TreatmentPlanService.exportStepSTL(plan)
+}
+</script>
+
+<style scoped>
+.plan-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+.plan-table th,
+.plan-table td {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 4px;
+  text-align: center;
+}
+.warning {
+  color: #fbbf24;
+  margin-left: 4px;
+}
+.panel-footer {
+  padding: 8px 12px;
+  display: flex;
+  justify-content: flex-end;
+}
+</style>

--- a/src/services/TreatmentPlanService.ts
+++ b/src/services/TreatmentPlanService.ts
@@ -1,0 +1,60 @@
+import type { ToothSegment, MovementDirection, TreatmentPlan, ToothMovementPlan } from '../types/dental'
+
+export const STANDARD_MOVEMENT_STEPS: Record<MovementDirection, number> = {
+  anteroposterior: 5,
+  vertical: 5,
+  transverse: 5,
+}
+
+export class TreatmentPlanService {
+  createPlan(segments: ToothSegment[]): TreatmentPlan {
+    const teeth: ToothMovementPlan[] = segments.map(segment => ({
+      toothId: segment.id,
+      toothName: segment.name,
+      schedules: [
+        { direction: 'anteroposterior', startStep: 0, steps: STANDARD_MOVEMENT_STEPS.anteroposterior },
+        { direction: 'vertical', startStep: 0, steps: STANDARD_MOVEMENT_STEPS.vertical },
+        { direction: 'transverse', startStep: 0, steps: STANDARD_MOVEMENT_STEPS.transverse },
+      ],
+    }))
+    return { teeth }
+  }
+
+  updateSchedule(
+    plan: TreatmentPlan,
+    toothId: string,
+    direction: MovementDirection,
+    startStep: number,
+    steps: number
+  ) {
+    const tooth = plan.teeth.find(t => t.toothId === toothId)
+    if (!tooth) return
+    const schedule = tooth.schedules.find(s => s.direction === direction)
+    if (schedule) {
+      schedule.startStep = startStep
+      schedule.steps = steps
+    }
+  }
+
+  validatePlan(plan: TreatmentPlan): string[] {
+    const warnings: string[] = []
+    for (const tooth of plan.teeth) {
+      for (const sched of tooth.schedules) {
+        const min = STANDARD_MOVEMENT_STEPS[sched.direction]
+        if (sched.steps < min) {
+          warnings.push(
+            `${tooth.toothName} ${sched.direction} movement has fewer steps (${sched.steps}) than recommended (${min}).`
+          )
+        }
+      }
+    }
+    return warnings
+  }
+
+  exportStepSTL(_plan: TreatmentPlan) {
+    // Placeholder for STL export logic per treatment step
+    console.warn('exportStepSTL is not implemented.')
+  }
+}
+
+export default new TreatmentPlanService()

--- a/src/types/dental.ts
+++ b/src/types/dental.ts
@@ -88,3 +88,24 @@ export interface SegmentData {
   color: string
   toothType?: string
 }
+
+export type MovementDirection =
+  | 'anteroposterior'
+  | 'vertical'
+  | 'transverse'
+
+export interface MovementSchedule {
+  direction: MovementDirection
+  startStep: number
+  steps: number
+}
+
+export interface ToothMovementPlan {
+  toothId: string
+  toothName: string
+  schedules: MovementSchedule[]
+}
+
+export interface TreatmentPlan {
+  teeth: ToothMovementPlan[]
+}


### PR DESCRIPTION
## Summary
- introduce orthodontic treatment plan data types to describe tooth movement schedules
- add TreatmentPlanService for plan creation, validation, and STL export placeholder
- provide TreatmentPlanPanel in sidebar for adjusting movement timing with warnings when steps below standard

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6890a098efb08322a3839da4c772a942